### PR TITLE
fix: remove async/await API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import deeppyer, asyncio
 
 def main():
     img = Image.open('./foo.jpg')
-    img = await deeppyer.deepfry(img)
+    img = deeppyer.deepfry(img)
     img.save('./bar.jpg')
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ in which case it is off by default.
 from PIL import Image
 import deeppyer, asyncio
 
-async def main():
+def main():
     img = Image.open('./foo.jpg')
     img = await deeppyer.deepfry(img)
     img.save('./bar.jpg')
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+if __name__ == "__main__":
+    main()
 ```
 
 ## API Documentation

--- a/deeppyer/__init__.py
+++ b/deeppyer/__init__.py
@@ -27,7 +27,7 @@ flare_img = Image.open(BytesIO(pkgutil.get_data(__package__, 'flare.png')))
 FlarePosition = namedtuple('FlarePosition', ['x', 'y', 'size'])
 
 
-async def deepfry(img: Image, *, colours: ColourTuple = DefaultColours.red, flares: bool = True) -> Image:
+def deepfry(img: Image, *, colours: ColourTuple = DefaultColours.red, flares: bool = True) -> Image:
     """
     Deepfry a given image.
 

--- a/deeppyer/cli.py
+++ b/deeppyer/cli.py
@@ -18,7 +18,6 @@ def main():
     img = Image.open(args.file)
     out = args.output or './deepfried.jpg'
 
-    loop = asyncio.get_event_loop()
-    img = loop.run_until_complete(deepfry(img, flares=args.flares))
+    img = deepfry(img, flares=args.flares)
 
     img.save(out, 'jpeg')

--- a/tests/test.py
+++ b/tests/test.py
@@ -6,7 +6,7 @@ from PIL import Image
 import deeppyer
 
 
-async def main():
+def main():
     print('[tests] Generating gradient image...')
     img = Image.new('RGB', (100, 100))
 
@@ -25,10 +25,10 @@ async def main():
 
     print('[tests] Deepfrying gradient...')
 
-    img2 = await deeppyer.deepfry(img)
+    img2 = deeppyer.deepfry(img)
     img2.save('./tests/gradient-fried.jpg')
 
-    img2 = await deeppyer.deepfry(img, type=deeppyer.DeepfryTypes.BLUE)
+    img2 = deeppyer.deepfry(img, colours=deeppyer.DefaultColours.blue)
     img2.save('./tests/gradient-fried-blue.jpg')
 
     print('[tests] Image successfully deepfried.'
@@ -38,10 +38,10 @@ async def main():
 
     img = Image.open('./tests/human-test.jpg')
 
-    img2 = await deeppyer.deepfry(img)
+    img2 = deeppyer.deepfry(img)
     img2.save('./tests/human-fried.jpg')
 
-    img2 = await deeppyer.deepfry(img, type=deeppyer.DeepfryTypes.BLUE)
+    img2 = deeppyer.deepfry(img, colours=deeppyer.DefaultColours.blue)
     img2.save('./tests/human-fried-blue.jpg')
 
     print('[tests] Human image successfully deepfried.'
@@ -49,5 +49,5 @@ async def main():
 
     print('[tests] All tests successfully completed.')
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR removes the async/await API that was introduced when deeppyer used Microsoft's image API.

The programmatic API is now reduced to:
```python
from PIL import Image
import deeppyer, asyncio

def main():
    img = Image.open('./foo.jpg')
    img = deeppyer.deepfry(img)
    img.save('./bar.jpg')

if __name__ == "__main__":
    main()
```

Closes #6 